### PR TITLE
New on_put Update use case

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -14,5 +14,6 @@ log = logging.getLogger()
 app = falcon.API(request_type=CustomRequest, middleware=[RequestMiddleware(), LoggingMiddleware()])
 app.add_route('/health', HealthHandler())
 app.add_route('/todos', TodosHandler())
+app.add_route('/todos/{todo_id}', TodosHandler())
 
 log.info("Started with config file: {}".format(settings.config_file))

--- a/api/handlers.py
+++ b/api/handlers.py
@@ -49,8 +49,11 @@ class TodosHandler(object):
                                 user=os.environ["DB_USER"],
                                 password=os.environ["DB_PASSWORD"])
         cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-        cur.execute("UPDATE public.todo SET (title, status) = ('{}', '{}') WHERE id = '{}' RETURNING *"
-                    .format(body['title'], body['status'], todo_id))
+        # Construct an UPDATE statement according to what column data is in the body,
+        # since updating a todo item usually doesn't require updating the title.
+        cur.execute("UPDATE public.todo SET {} WHERE id = '{}' RETURNING *"
+                    .format(", ".join('{} = \'{}\''.format(i[0], i[1]) for i in body.items()),
+                            todo_id))
         updated_todo = cur.fetchall()
         conn.commit()
         cur.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ falcon
 PyYAML
 easydict
 psycopg2
+pytest
+pytest-falcon

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -1,0 +1,20 @@
+from falcon import testing
+from api.app import app
+import pytest
+from urllib.parse import urlencode
+
+
+@pytest.fixture()
+def client():
+    return testing.TestClient(app)
+
+
+def test_put_update(client):
+    headers = {"Content-Type": "application/json"}
+    todo = urlencode({"title": "Test PUT Update", "status": "In progress"})
+    client.simulate_post('/todos', headers=headers, body=todo)
+
+    update = urlencode({"title": "Test PUT Update...", "status": "Valid case done"})
+    expected_resp = {"id": 1, "title": "Test PUT Update...", "status": "Valid case done"}
+    result = client.simulate_put('/todos/1', headers=headers, body=update)
+    assert result.json == expected_resp


### PR DESCRIPTION
Added a new PUT endpoint on '/todos/{todoID}' for updating existing ToDo items' titles and/or statuses.